### PR TITLE
docs: publish online skill configuration artifacts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-# Portkey EOA Agent Skills Configuration
-# Copy this file to .env and fill in your values
+# Portkey EOA Agent Skills Configuration.
+# Public chain and asset queries work without secrets.
 
 # Network (mainnet)
 PORTKEY_NETWORK=mainnet
@@ -7,14 +7,20 @@ PORTKEY_NETWORK=mainnet
 # (Optional) Override API base URL
 # PORTKEY_API_URL=https://eoa-portkey.portkey.finance
 
-# (Optional) Plaintext private key for direct usage
-# PORTKEY_PRIVATE_KEY=your_64_hex_char_private_key
+# Chain RPC and default MultiToken addresses are discovered from the API chain-info
+# fields endPoint and defaultToken.address; generic contract/bridge targets are inputs.
+
+# (Optional) Plaintext private key for write operations. Prefer encrypted wallets.
+PORTKEY_PRIVATE_KEY=
 
 # (Optional) Custom wallet storage directory (default: ~/.portkey/eoa/wallets/)
 # PORTKEY_WALLET_DIR=/path/to/wallets
 
 # (Optional) Password for encrypting/decrypting local wallet files
-# PORTKEY_WALLET_PASSWORD=your_wallet_password
+# PORTKEY_WALLET_PASSWORD=
 
 # (Optional) Override the default read-only private key used for view-only contract calls
-# PORTKEY_READONLY_PRIVATE_KEY=your_64_hex_char_readonly_key
+# PORTKEY_READONLY_PRIVATE_KEY=
+
+# (Optional) Shared signer context path for cross-skill workflows
+# PORTKEY_SKILL_WALLET_CONTEXT_PATH=

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,37 +1,9 @@
 ---
-name: "portkey-eoa-agent-skills"
-version: "1.2.6"
-description: "Portkey EOA wallet and asset operations for aelf agents."
-activation:
-  keywords:
-    - wallet
-    - eoa
-    - transfer
-    - token
-    - nft
-    - aelf
-    - balance
-    - create wallet
-    - import wallet
-  exclude_keywords:
-    - ca
-    - guardian
-    - recovery
-    - ca hash
-    - ca wallet
-  tags:
-    - wallet
-    - blockchain
-    - aelf
-    - portkey
-  max_context_tokens: 1800
+name: portkey-eoa-agent-skills
+description: Portkey EOA wallet lifecycle and asset operations for creating, importing, listing, backing up, selecting, and deleting wallets; querying tokens, NFTs, prices, balances, and history; and performing transfers, approvals, bridge, view, send, and fee estimation operations on AElf. Use by default for direct EOA wallets; use the Portkey CA skill for guardian, recovery, CA hash, or Contract Account workflows.
 ---
 
 # Portkey EOA Agent Skill
-
-## When to use
-- Use this skill when you need EOA wallet management, transfers, asset queries, and contract calls.
-- Default to the EOA wallet path unless the user explicitly asks for CA identity, guardian, or recovery flows.
 
 ## Capabilities
 - Wallet lifecycle: create, import, list, backup, delete
@@ -39,6 +11,12 @@ activation:
 - Asset/query operations: token balances, NFTs, history, prices
 - Transfer and contract execution via CLI/MCP/SDK adapters
 - Supports SDK, CLI, MCP, OpenClaw, and IronClaw integration from one codebase.
+
+## Online configuration
+- Portkey EOA uses `mainnet` and the public API `https://eoa-portkey.portkey.finance`; public chain and asset reads need no credentials.
+- Chain RPC and default MultiToken addresses are loaded from the API chain-info response (`endPoint` and `defaultToken.address`) and cached per network instead of being hardcoded.
+- Generic contract and bridge tools require caller-supplied target contract addresses because those deployments are operation-specific.
+- Wallet files default to `~/.portkey/eoa/wallets/`; override storage, API, signer, read-only key, and shared wallet context through the variables in `.env.example`.
 
 ## Safe usage rules
 - Never print private keys, mnemonics, auto-generated passwords, or tokens in channel outputs.

--- a/ironclaw-wasm/Cargo.lock
+++ b/ironclaw-wasm/Cargo.lock
@@ -1108,7 +1108,7 @@ checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "portkey_eoa_ironclaw"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "aelf-sdk",
  "async-trait",

--- a/ironclaw-wasm/Cargo.toml
+++ b/ironclaw-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "portkey_eoa_ironclaw"
-version = "1.2.6"
+version = "1.2.7"
 edition = "2021"
 description = "Portkey EOA native IronClaw WASM tool"
 license = "MIT"

--- a/ironclaw-wasm/portkey-eoa-ironclaw.capabilities.json
+++ b/ironclaw-wasm/portkey-eoa-ironclaw.capabilities.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.6",
+  "version": "1.2.7",
   "wit_version": "0.3.0",
   "capabilities": {
     "http": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@portkey/eoa-agent-skills",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "AI Agent Skills for Portkey EOA Wallet — MCP, CLI, and SDK interfaces for wallet management, token transfers, asset queries, and contract interactions on aelf blockchain.",
   "type": "module",
   "main": "index.ts",
@@ -25,7 +25,8 @@
     "mcp-config.example.json",
     "README.md",
     "README.zh-CN.md",
-    "LICENSE"
+    "LICENSE",
+    ".env.example"
   ],
   "repository": {
     "type": "git",

--- a/tests/unit/ironclaw-skill.test.ts
+++ b/tests/unit/ironclaw-skill.test.ts
@@ -1,108 +1,45 @@
 import { describe, expect, test } from 'bun:test';
 import { fileURLToPath } from 'node:url';
-import packageJson from '../../package.json';
 
 function getSkillParts() {
   const skillPath = fileURLToPath(new URL('../../SKILL.md', import.meta.url));
-  const raw = Bun.file(skillPath).text();
-  return raw.then((content) => {
+  return Bun.file(skillPath).text().then((content) => {
     const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
-    if (!match) {
-      throw new Error('SKILL.md is missing YAML frontmatter');
-    }
-    return {
-      frontmatter: match[1],
-      body: match[2],
-    };
+    if (!match) throw new Error('SKILL.md is missing YAML frontmatter');
+    return { frontmatter: match[1], body: match[2] };
   });
 }
 
-function getActivationList(frontmatter: string, key: string): string[] {
-  const lines = frontmatter.split('\n');
-  const results: string[] = [];
-  let inActivation = false;
-  let capture = false;
-
-  for (const line of lines) {
-    if (!inActivation) {
-      if (line.trim() === 'activation:') {
-        inActivation = true;
-      }
-      continue;
-    }
-
-    if (/^\S/.test(line)) {
-      break;
-    }
-
-    if (new RegExp(`^  ${key}:\\s*$`).test(line)) {
-      capture = true;
-      continue;
-    }
-
-    if (capture && /^  [a-zA-Z_]/.test(line)) {
-      break;
-    }
-
-    if (!capture) {
-      continue;
-    }
-
-    const item = line.match(/^    -\s*(.+)$/);
-    if (item) {
-      results.push(item[1].trim().replace(/^['"]|['"]$/g, ''));
-    }
-  }
-
-  return results;
+function getTopLevelKeys(frontmatter: string): string[] {
+  return frontmatter.split('\n').flatMap((line) => {
+    const match = line.match(/^([a-zA-Z][\w-]*):/);
+    return match ? [match[1]] : [];
+  });
 }
 
-function getActivationNumber(frontmatter: string, key: string): number | null {
-  const match = frontmatter.match(new RegExp(`^  ${key}:\\s*(\\d+)$`, 'm'));
-  return match ? Number(match[1]) : null;
+function getFrontmatterValue(frontmatter: string, key: string): string {
+  return frontmatter.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'))?.[1]?.trim() ?? '';
 }
 
 describe('IronClaw skill prompt', () => {
-  test('includes versioned frontmatter that matches package version', async () => {
+  test('uses only Codex-supported frontmatter fields', async () => {
     const { frontmatter } = await getSkillParts();
-    expect(frontmatter).toContain('name: "portkey-eoa-agent-skills"');
-    expect(frontmatter).toContain(`version: "${packageJson.version}"`);
-    expect(frontmatter).toContain('activation:');
+    expect(getTopLevelKeys(frontmatter)).toEqual(['name', 'description']);
+    expect(getFrontmatterValue(frontmatter, 'name')).toBe('portkey-eoa-agent-skills');
   });
 
-  test('defines activation keywords, exclusions, and tags for IronClaw routing', async () => {
+  test('routes EOA work through the description', async () => {
     const { frontmatter } = await getSkillParts();
-    const keywords = getActivationList(frontmatter, 'keywords');
-    const excludeKeywords = getActivationList(frontmatter, 'exclude_keywords');
-    const tags = getActivationList(frontmatter, 'tags');
-
-    expect(keywords).toEqual(
-      expect.arrayContaining([
-        'wallet',
-        'eoa',
-        'transfer',
-        'token',
-        'nft',
-        'aelf',
-      ]),
-    );
-    expect(excludeKeywords).toEqual(
-      expect.arrayContaining([
-        'ca',
-        'guardian',
-        'recovery',
-        'ca hash',
-      ]),
-    );
-    expect(tags).toEqual(
-      expect.arrayContaining(['wallet', 'blockchain', 'aelf', 'portkey']),
-    );
-    expect(getActivationNumber(frontmatter, 'max_context_tokens')).toBe(1800);
+    const description = getFrontmatterValue(frontmatter, 'description').toLowerCase();
+    expect(description).toContain('eoa');
+    expect(description).toContain('wallet');
+    expect(description).toContain('transfer');
+    expect(description).toContain('ca');
+    expect(description).toContain('guardian');
   });
 
-  test('documents EOA default path, confirmation rules, and active wallet context', async () => {
+  test('documents confirmation, key safety, and active wallet context', async () => {
     const { body } = await getSkillParts();
-    expect(body).toContain('Default to the EOA wallet path');
     expect(body).toContain('Require explicit user confirmation before write operations');
     expect(body).toContain('Never print private keys, mnemonics');
     expect(body).toContain('tokens in channel outputs');


### PR DESCRIPTION
Summary:
- document current online services and contract address sources
- include SKILL.md and .env.example in the npm package
- align skill frontmatter with Codex-supported fields
- align IronClaw WASM and capability manifest versions
- bump the release version to 1.2.7

Validation:
- TypeScript typecheck
- skill frontmatter and routing contract tests
- OpenClaw generated artifact check
- npm pack dry-run confirms SKILL.md and .env.example